### PR TITLE
Adds astro keywords to packages with .astro file exports

### DIFF
--- a/packages/astro-embed-twitter/package.json
+++ b/packages/astro-embed-twitter/package.json
@@ -17,6 +17,12 @@
     "type": "git",
     "url": "git+https://github.com/astro-community/astro-embed.git"
   },
+  "keywords": [
+    "astro",
+    "astro-component",
+    "embeds",
+    "twitter"
+  ],
   "author": "delucis",
   "license": "MIT",
   "bugs": {

--- a/packages/astro-embed-youtube/package.json
+++ b/packages/astro-embed-youtube/package.json
@@ -16,6 +16,12 @@
     "type": "git",
     "url": "git+https://github.com/astro-community/astro-embed.git"
   },
+  "keywords": [
+    "astro",
+    "astro-component",
+    "embeds",
+    "youtube"
+  ],
   "author": "delucis",
   "license": "MIT",
   "bugs": {

--- a/packages/astro-embed/package.json
+++ b/packages/astro-embed/package.json
@@ -16,9 +16,11 @@
     "url": "git+https://github.com/astro-community/astro-embed.git"
   },
   "keywords": [
+    "astro",
     "astro-component",
     "embeds",
-    "twitter"
+    "twitter",
+    "youtube"
   ],
   "author": "delucis",
   "license": "MIT",


### PR DESCRIPTION
Adds astro and astro-component keywords to packages containing .astro file exports. This should enable Astro to detect and add to vite.ssr.noExternal in astro.config.