### PR TITLE
Add Vimeo embed support

### DIFF
--- a/.changeset/witty-candles-reply.md
+++ b/.changeset/witty-candles-reply.md
@@ -1,0 +1,7 @@
+---
+"astro-embed": patch
+"@astro-community/astro-embed-integration": patch
+"@astro-community/astro-embed-vimeo": minor
+---
+
+Add Vimeo embed support

--- a/demo/src/pages/index.astro
+++ b/demo/src/pages/index.astro
@@ -8,6 +8,9 @@ import Base from '../layouts/Base.astro';
 			<a href="/twitter"><code>&lt;Tweet/&gt;</code> component examples</a>
 		</li>
 		<li>
+			<a href="/vimeo"><code>&lt;Vimeo/&gt;</code> component examples</a>
+		</li>
+		<li>
 			<a href="/youtube"><code>&lt;YouTube/&gt;</code> component examples</a>
 		</li>
 		<li>

--- a/demo/src/pages/integration.md
+++ b/demo/src/pages/integration.md
@@ -18,4 +18,6 @@ defineConfig({
 
 https://twitter.com/astrodotbuild/status/1511750228428435457
 
+https://vimeo.com/32001208
+
 http://www.youtube.com/watch?v=Hoe-woAhq_k

--- a/demo/src/pages/vimeo.astro
+++ b/demo/src/pages/vimeo.astro
@@ -1,0 +1,40 @@
+---
+import { Vimeo } from '@astro-community/astro-embed-vimeo';
+import Base from '../layouts/Base.astro';
+---
+
+<Base title="Vimeo component examples">
+	<h2>With just the ID</h2>
+	<p><code>&lt;Vimeo id="32001208" /&gt;</code></p>
+	<Vimeo id="32001208" />
+
+	<h2>With a full vimeo.com URL</h2>
+	<p>
+		<code>&lt;Vimeo id="https://vimeo.com/32001208" /&gt;</code>
+	</p>
+	<Vimeo id="https://vimeo.com/32001208" />
+
+	<h2>With “www.” in the URL</h2>
+	<p>
+		<code>&lt;Vimeo id="https://www.vimeo.com/32001208" /&gt;</code>
+	</p>
+	<Vimeo id="https://www.vimeo.com/32001208" />
+
+	<h2>With custom parameters</h2>
+	<p>
+		<code
+			>&lt;Vimeo id="https://vimeo.com/32001208" params="color=ff0000&muted=1"
+			/&gt;</code
+		>
+	</p>
+	<Vimeo id="https://vimeo.com/32001208" params="color=ff0000&muted=1" />
+
+	<h2>With custom timestamp</h2>
+	<p>
+		<code
+			>&lt;Vimeo id="https://vimeo.com/32001208" params="color=00ff00#t=2m00s"
+			/&gt;</code
+		>
+	</p>
+	<Vimeo id="https://vimeo.com/32001208" params="color=00ff00#t=2m00s" />
+</Base>

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,10 @@
       "resolved": "packages/astro-embed-utils",
       "link": true
     },
+    "node_modules/@astro-community/astro-embed-vimeo": {
+      "resolved": "packages/astro-embed-vimeo",
+      "link": true
+    },
     "node_modules/@astro-community/astro-embed-youtube": {
       "resolved": "packages/astro-embed-youtube",
       "link": true
@@ -4852,6 +4856,11 @@
         "uhyphen": "^0.1.0"
       }
     },
+    "node_modules/lite-vimeo-embed": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lite-vimeo-embed/-/lite-vimeo-embed-0.1.0.tgz",
+      "integrity": "sha512-XFzPdv4NaWlyaM9WpBaS5CIUkf+laIRZEXQGsBb2ZdDWkuMmnzfAZ5nriYv3a3MVx5tEEetGN0sNaUhAVRXr1g=="
+    },
     "node_modules/lite-youtube-embed": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/lite-youtube-embed/-/lite-youtube-embed-0.2.0.tgz",
@@ -9189,6 +9198,7 @@
       "dependencies": {
         "@astro-community/astro-embed-integration": "^0.1.0",
         "@astro-community/astro-embed-twitter": "^0.1.3",
+        "@astro-community/astro-embed-vimeo": "^0.0.1",
         "@astro-community/astro-embed-youtube": "^0.1.1"
       },
       "peerDependencies": {
@@ -9201,6 +9211,7 @@
       "license": "MIT",
       "dependencies": {
         "@astro-community/astro-embed-twitter": "^0.1.0",
+        "@astro-community/astro-embed-vimeo": "^0.0.1",
         "@astro-community/astro-embed-youtube": "^0.1.0",
         "unist-util-select": "^4.0.1"
       },
@@ -9223,6 +9234,17 @@
       "name": "@astro-community/astro-embed-utils",
       "version": "0.0.3",
       "license": "MIT"
+    },
+    "packages/astro-embed-vimeo": {
+      "name": "@astro-community/astro-embed-vimeo",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "lite-vimeo-embed": "^0.1.0"
+      },
+      "peerDependencies": {
+        "astro": "^1.0.0-beta.10"
+      }
     },
     "packages/astro-embed-youtube": {
       "name": "@astro-community/astro-embed-youtube",
@@ -9269,6 +9291,7 @@
       "version": "file:packages/astro-embed-integration",
       "requires": {
         "@astro-community/astro-embed-twitter": "^0.1.0",
+        "@astro-community/astro-embed-vimeo": "^0.0.1",
         "@astro-community/astro-embed-youtube": "^0.1.0",
         "unist-util-select": "^4.0.1"
       }
@@ -9281,6 +9304,12 @@
     },
     "@astro-community/astro-embed-utils": {
       "version": "file:packages/astro-embed-utils"
+    },
+    "@astro-community/astro-embed-vimeo": {
+      "version": "file:packages/astro-embed-vimeo",
+      "requires": {
+        "lite-vimeo-embed": "^0.1.0"
+      }
     },
     "@astro-community/astro-embed-youtube": {
       "version": "file:packages/astro-embed-youtube",
@@ -10826,6 +10855,7 @@
       "requires": {
         "@astro-community/astro-embed-integration": "^0.1.0",
         "@astro-community/astro-embed-twitter": "^0.1.3",
+        "@astro-community/astro-embed-vimeo": "^0.0.1",
         "@astro-community/astro-embed-youtube": "^0.1.1"
       }
     },
@@ -12560,6 +12590,11 @@
         "htmlparser2": "^7.2.0",
         "uhyphen": "^0.1.0"
       }
+    },
+    "lite-vimeo-embed": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lite-vimeo-embed/-/lite-vimeo-embed-0.1.0.tgz",
+      "integrity": "sha512-XFzPdv4NaWlyaM9WpBaS5CIUkf+laIRZEXQGsBb2ZdDWkuMmnzfAZ5nriYv3a3MVx5tEEetGN0sNaUhAVRXr1g=="
     },
     "lite-youtube-embed": {
       "version": "0.2.0",

--- a/packages/astro-embed-integration/package.json
+++ b/packages/astro-embed-integration/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/astro-community/astro-embed/tree/main/packages/astro-embed-integration#readme",
   "dependencies": {
     "@astro-community/astro-embed-twitter": "^0.1.0",
+    "@astro-community/astro-embed-vimeo": "^0.0.1",
     "@astro-community/astro-embed-youtube": "^0.1.0",
     "unist-util-select": "^4.0.1"
   },

--- a/packages/astro-embed-integration/remark-plugin.js
+++ b/packages/astro-embed-integration/remark-plugin.js
@@ -1,10 +1,12 @@
 import { selectAll } from 'unist-util-select';
 import twitterMatcher from '@astro-community/astro-embed-twitter/matcher';
+import vimeoMatcher from '@astro-community/astro-embed-vimeo/matcher';
 import youtubeMatcher from '@astro-community/astro-embed-youtube/matcher';
 
 /** @type {[(url: string) => string | undefined, string][]} */
 const matchers = [
 	[twitterMatcher, 'Tweet'],
+	[vimeoMatcher, 'Vimeo'],
 	[youtubeMatcher, 'YouTube'],
 ];
 

--- a/packages/astro-embed-vimeo/README.md
+++ b/packages/astro-embed-vimeo/README.md
@@ -1,0 +1,59 @@
+# `@astro-community/astro-embed-vimeo`
+
+This package contains a component for embedding Vimeo videos in Astro projects.
+
+## Install
+
+```bash
+npm i @astro-community/astro-embed-vimeo
+```
+
+## Usage
+
+### `<Vimeo id={video_id_or_url} />`
+
+The **Vimeo** component generates an embed using a `lite-vimeo` custom element. Vimeo embeds will always require some JavaScript, but this is one of the most minimal and performant ways to embed a Vimeo video.
+
+```astro
+---
+import { Vimeo } from '@astro-community/astro-embed-vimeo';
+---
+
+<Vimeo id="32001208" />
+```
+
+You can also pass in the full URL for the video:
+
+```astro
+<Vimeo id="https://vimeo.com/32001208" />
+```
+
+#### Optional props
+
+##### `poster`
+
+You can provide an alternative poster image by passing in a URL to the `poster` prop.
+
+```astro
+<Vimeo
+  id="32001208"
+  poster="https://images-assets.nasa.gov/image/0302063/0302063~orig.jpg"
+/>
+```
+
+##### `params`
+
+You can pass a `params` prop to set the [player parameters supported by Vimeo](https://vimeo.zendesk.com/hc/en-us/articles/360001494447-Player-parameters-overview). This looks like a series of URL search params.
+
+```astro
+<!-- Example: Set the UI color to red and mute by default. -->
+<Vimeo id="32001208" params="color=ff0000&muted=1" />
+```
+
+##### `playlabel`
+
+By default, the play button in the embed has an accessible label set to “Play”. If you want to customise this, you can set the `playlabel` prop.
+
+```astro
+<Vimeo id="32001208" playlabel="Play the video" />
+```

--- a/packages/astro-embed-vimeo/Vimeo.astro
+++ b/packages/astro-embed-vimeo/Vimeo.astro
@@ -1,0 +1,131 @@
+---
+import { safeGet } from '@astro-community/astro-embed-utils';
+import urlMatcher from './matcher';
+import './Vimeo.css';
+
+export interface Props {
+	/** Vimeo video ID or URL. */
+	id: string;
+	/** URL to an image to use as the poster instead of the default thumbnail. */
+	poster?: string;
+	/** See https://vimeo.zendesk.com/hc/en-us/articles/360001494447-Player-parameters-overview */
+	params?: string;
+	/** Label for the button that will play the video. Default label: `'Play'` */
+	playlabel?: string;
+}
+
+const { id, poster, params = '', playlabel = 'Play' } = Astro.props as Props;
+
+const idRegExp = /^\d+$/;
+
+function extractID(idOrUrl: string) {
+	if (idRegExp.test(idOrUrl)) return idOrUrl;
+	return urlMatcher(idOrUrl);
+}
+
+const videoid = extractID(id);
+let posterURL = poster;
+if (!posterURL) {
+	const data = await safeGet(`https://vimeo.com/api/v2/video/${videoid}.json`);
+	const { thumbnail_large } = data?.[0] || {};
+	posterURL = thumbnail_large;
+}
+
+let [searchString, t] = params.split('#t=');
+const searchParams = new URLSearchParams(searchString);
+if (!t) t = searchParams.get('t');
+searchParams.append('autoplay', '1');
+if (!searchParams.has('dnt')) searchParams.append('dnt', '1');
+
+const color = searchParams.get('color');
+
+const styles = [];
+if (color) styles.push(`--ltv-color: #${color}`);
+if (posterURL) styles.push(`background-image: url('${posterURL}')`);
+---
+
+<lite-vimeo
+	data-id={videoid}
+	data-t={t}
+	data-params={searchParams.toString()}
+	style={styles.join(';')}
+>
+	<button class="ltv-playbtn" type="button" aria-label={playlabel}></button>
+</lite-vimeo>
+
+<script>
+	class LiteVimeo extends HTMLElement {
+		videoId: string;
+		static preconnected = false;
+
+		connectedCallback() {
+			// Gotta encode the untrusted value to prevent XSS.
+			this.videoId = encodeURIComponent(this.dataset.id);
+
+			// On hover (or tap), warm up the TCP connections we're (likely) about to use.
+			this.addEventListener('pointerover', LiteVimeo.warmConnections, {
+				once: true,
+			});
+
+			// Once the user clicks, add the real iframe and drop our play button
+			this.addEventListener('click', (e) => this.addIframe(e));
+		}
+
+		/**
+		 * Add a <link rel={preload | preconnect} ...> to the head
+		 */
+		static addPrefetch(rel: string, url: string): void {
+			const linkEl = document.createElement('link');
+			linkEl.rel = rel;
+			linkEl.href = url;
+			document.head.append(linkEl);
+		}
+
+		/**
+		 * Begin pre-connecting to warm up the iframe load
+		 * Since the embed's network requests load within its iframe,
+		 *   preload/prefetch'ing them outside the iframe will only cause double-downloads.
+		 * So, the best we can do is warm up a few connections to origins that are in the critical path.
+		 *
+		 * Maybe `<link rel=preload as=document>` would work, but it's unsupported: http://crbug.com/593267
+		 * But TBH, I don't think it'll happen soon with Site Isolation and split caches adding serious complexity.
+		 */
+		static warmConnections(): void {
+			if (LiteVimeo.preconnected) return;
+
+			// The iframe document and most of its subresources come right off player.vimeo.com
+			LiteVimeo.addPrefetch('preconnect', 'https://player.vimeo.com');
+			// Images
+			LiteVimeo.addPrefetch('preconnect', 'https://i.vimeocdn.com');
+			// Files .js, .css
+			LiteVimeo.addPrefetch('preconnect', 'https://f.vimeocdn.com');
+			// Metrics
+			LiteVimeo.addPrefetch('preconnect', 'https://fresnel.vimeocdn.com');
+
+			LiteVimeo.preconnected = true;
+		}
+
+		addIframe(e: MouseEvent): void {
+			if (this.classList.contains('ltv-activated')) return;
+			e.preventDefault();
+			this.classList.add('ltv-activated');
+
+			const t = encodeURIComponent(this.dataset.t || '0m');
+			const params = new URLSearchParams(this.dataset.params || []);
+
+			const iframeEl = document.createElement('iframe');
+			iframeEl.width = '640';
+			iframeEl.height = '360';
+			iframeEl.allow =
+				'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture';
+			iframeEl.allowFullscreen = true;
+			iframeEl.src = `https://player.vimeo.com/video/${
+				this.videoId
+			}?${params.toString()}#t=${t}`;
+			this.append(iframeEl);
+		}
+	}
+
+	// Register custom element
+	customElements.define('lite-vimeo', LiteVimeo);
+</script>

--- a/packages/astro-embed-vimeo/Vimeo.css
+++ b/packages/astro-embed-vimeo/Vimeo.css
@@ -1,0 +1,70 @@
+lite-vimeo {
+	font-size: 10px;
+	background-color: #000;
+	position: relative;
+	display: block;
+	contain: content;
+	background-position: center center;
+	background-size: cover;
+	cursor: pointer;
+}
+
+/* responsive iframe with a 16:9 aspect ratio
+	thanks https://css-tricks.com/responsive-iframes/
+*/
+lite-vimeo::after {
+	content: '';
+	display: block;
+	padding-bottom: calc(100% / (16 / 9));
+}
+lite-vimeo > iframe {
+	width: 100%;
+	height: 100%;
+	position: absolute;
+	top: 0;
+	left: 0;
+}
+
+/* play button */
+lite-vimeo > .ltv-playbtn {
+	width: 6.5em;
+	height: 4em;
+	background: rgba(23, 35, 34, 0.75);
+	z-index: 1;
+	opacity: 0.8;
+	border-radius: 0.5em; /* TODO: Consider replacing this with YT's actual svg. Eh. */
+	transition: all 0.2s cubic-bezier(0, 0, 0.2, 1);
+	outline: 0;
+	border: 0;
+	cursor: pointer;
+}
+lite-vimeo:hover > .ltv-playbtn {
+	background-color: rgb(0, 173, 239);
+	background-color: var(--ltv-color, rgb(0, 173, 239));
+	opacity: 1;
+}
+/* play button triangle */
+lite-vimeo > .ltv-playbtn::before {
+	content: '';
+	border-style: solid;
+	border-width: 10px 0 10px 20px;
+	border-color: transparent transparent transparent #fff;
+}
+
+lite-vimeo > .ltv-playbtn,
+lite-vimeo > .ltv-playbtn::before {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate3d(-50%, -50%, 0);
+}
+
+/* Post-click styles */
+lite-vimeo.ltv-activated {
+	cursor: unset;
+}
+lite-vimeo.ltv-activated::before,
+lite-vimeo.ltv-activated > .ltv-playbtn {
+	opacity: 0;
+	pointer-events: none;
+}

--- a/packages/astro-embed-vimeo/index.js
+++ b/packages/astro-embed-vimeo/index.js
@@ -1,0 +1,1 @@
+export { default as Vimeo } from './Vimeo.astro';

--- a/packages/astro-embed-vimeo/matcher.js
+++ b/packages/astro-embed-vimeo/matcher.js
@@ -1,0 +1,14 @@
+// Thanks to eleventy-plugin-vimeo-embed
+// https://github.com/gfscott/eleventy-plugin-vimeo-embed/blob/main/lib/extractMatches.js
+const urlPattern =
+	/(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:\/\/)??(?:w{3}\.)??(?:vimeo\.com)\/(\d{1,20})(?:[^\s<>]*)(?=(\s*))\4(?:<\/a>)??(?=(\s*))\5/;
+
+/**
+ * Extract a Vimeo ID from a URL if it matches the pattern.
+ * @param {string} url URL to test
+ * @returns {string|undefined} A Vimeo video ID or undefined if none matched
+ */
+export default function matcher(url) {
+	const match = url.match(urlPattern);
+	return match?.[3];
+}

--- a/packages/astro-embed-vimeo/package.json
+++ b/packages/astro-embed-vimeo/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@astro-community/astro-embed-vimeo",
+  "version": "0.0.1",
+  "description": "Component to easily embed Vimeo videos on your Astro site",
+  "type": "module",
+  "exports": {
+    ".": "./index.js",
+    "./matcher": "./matcher.js"
+  },
+  "files": [
+    "index.js",
+    "matcher.js",
+    "Vimeo.astro"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/astro-community/astro-embed.git"
+  },
+  "keywords": [
+    "astro",
+    "astro-component",
+    "embeds",
+    "vimeo"
+  ],
+  "author": "delucis",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/astro-community/astro-embed/issues"
+  },
+  "homepage": "https://github.com/astro-community/astro-embed/tree/main/packages/astro-embed-vimeo#readme",
+  "dependencies": {
+    "lite-vimeo-embed": "^0.1.0"
+  },
+  "peerDependencies": {
+    "astro": "^1.0.0-beta.10"
+  }
+}

--- a/packages/astro-embed/index.js
+++ b/packages/astro-embed/index.js
@@ -1,2 +1,3 @@
 export { Tweet } from '@astro-community/astro-embed-twitter';
 export { YouTube } from '@astro-community/astro-embed-youtube';
+export { Vimeo } from '@astro-community/astro-embed-vimeo';

--- a/packages/astro-embed/package.json
+++ b/packages/astro-embed/package.json
@@ -20,6 +20,7 @@
     "astro-component",
     "embeds",
     "twitter",
+    "vimeo",
     "youtube"
   ],
   "author": "delucis",
@@ -31,6 +32,7 @@
   "dependencies": {
     "@astro-community/astro-embed-integration": "^0.1.0",
     "@astro-community/astro-embed-twitter": "^0.1.3",
+    "@astro-community/astro-embed-vimeo": "^0.0.1",
     "@astro-community/astro-embed-youtube": "^0.1.1"
   },
   "peerDependencies": {

--- a/tests/astro-embed-vimeo.ts
+++ b/tests/astro-embed-vimeo.ts
@@ -1,0 +1,38 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { renderDOM } from './utils/render';
+
+const videoid = '32001208';
+
+test('it should render a lite-vimeo element', async () => {
+	const { window } = await renderDOM(
+		'./packages/astro-embed-vimeo/Vimeo.astro',
+		{ id: videoid }
+	);
+	const embed = window.document.querySelector('lite-vimeo');
+	assert.ok(embed);
+	assert.is(embed.getAttribute('data-id'), videoid);
+});
+
+test('it parses a Vimeo URL', async () => {
+	const { window } = await renderDOM(
+		'./packages/astro-embed-vimeo/Vimeo.astro',
+		{ id: 'https://vimeo.com/' + videoid }
+	);
+	const embed = window.document.querySelector('lite-vimeo');
+	assert.ok(embed);
+	assert.is(embed.getAttribute('data-id'), videoid);
+});
+
+test('it can set a custom poster image', async () => {
+	const poster = 'https://example.com/i.png';
+	const { window } = await renderDOM(
+		'./packages/astro-embed-vimeo/Vimeo.astro',
+		{ id: videoid, poster }
+	);
+	const embed = window.document.querySelector('lite-vimeo');
+	assert.ok(embed);
+	assert.is(embed.style['background-image'], `url('${poster}')`);
+});
+
+test.run();


### PR DESCRIPTION
This PR adds a new package to support embedding Vimeo videos! Uses a custom `<lite-vimeo>` web component implementation as we can simplify the component even more than existing solutions thanks to the server-side rendering Astro will do.