### PR TITLE
Fix empty entities tweet

### DIFF
--- a/.changeset/slimy-cheetahs-kick.md
+++ b/.changeset/slimy-cheetahs-kick.md
@@ -1,0 +1,5 @@
+---
+"@astro-community/astro-embed-twitter": patch
+---
+
+Check `entities` is defined before reading from it

--- a/packages/astro-embed-twitter/Tweet.astro
+++ b/packages/astro-embed-twitter/Tweet.astro
@@ -84,7 +84,7 @@ function buildContent(tweet: Awaited<ReturnType<typeof fetchTweet>>) {
 	let video = '';
 	let imageCount = 0;
 
-	if (tweet.data.entities.urls) {
+	if (tweet.data.entities?.urls) {
 		tweet.data.entities.urls.forEach(
 			({ url, display_url, expanded_url, media_key }) => {
 				text = text.replace(
@@ -95,7 +95,7 @@ function buildContent(tweet: Awaited<ReturnType<typeof fetchTweet>>) {
 		);
 	}
 
-	if (tweet.data.entities.mentions) {
+	if (tweet.data.entities?.mentions) {
 		tweet.data.entities.mentions.forEach(({ username }) => {
 			text = text.replace(
 				`@${username}`,
@@ -104,7 +104,7 @@ function buildContent(tweet: Awaited<ReturnType<typeof fetchTweet>>) {
 		});
 	}
 
-	if (tweet.data.entities.hashtags) {
+	if (tweet.data.entities?.hashtags) {
 		tweet.data.entities.hashtags.forEach(({ tag }) => {
 			text = text.replace(
 				`#${tag}`,

--- a/tests/astro-embed-twitter.ts
+++ b/tests/astro-embed-twitter.ts
@@ -20,4 +20,13 @@ test('it should render if passed a full URL', async () => {
 	assert.is(username.getAttribute('href'), 'https://twitter.com/astrodotbuild');
 });
 
+test('it does not crush when we have empty entities', async () => {
+	const screen = await renderScreen(
+		'./packages/astro-embed-twitter/Tweet.astro',
+		{ id: 'https://twitter.com/addyosmani/status/1600553460180869120' }
+	);
+	const username = screen.getByText('@addyosmani');
+	assert.is(username.getAttribute('href'), 'https://twitter.com/addyosmani');
+});
+
 test.run();

--- a/tests/astro-embed-twitter.ts
+++ b/tests/astro-embed-twitter.ts
@@ -20,7 +20,7 @@ test('it should render if passed a full URL', async () => {
 	assert.is(username.getAttribute('href'), 'https://twitter.com/astrodotbuild');
 });
 
-test('it does not crush when we have undefined entities', async () => {
+test('it does not crash when we have undefined entities', async () => {
 	const screen = await renderScreen(
 		'./packages/astro-embed-twitter/Tweet.astro',
 		{ id: 'https://twitter.com/addyosmani/status/1600553460180869120' }

--- a/tests/astro-embed-twitter.ts
+++ b/tests/astro-embed-twitter.ts
@@ -20,7 +20,7 @@ test('it should render if passed a full URL', async () => {
 	assert.is(username.getAttribute('href'), 'https://twitter.com/astrodotbuild');
 });
 
-test('it does not crush when we have empty entities', async () => {
+test('it does not crush when we have undefined entities', async () => {
 	const screen = await renderScreen(
 		'./packages/astro-embed-twitter/Tweet.astro',
 		{ id: 'https://twitter.com/addyosmani/status/1600553460180869120' }


### PR DESCRIPTION
This PR fix Tweet component crush when Twitter API return no entities somehow like in `https://twitter.com/addyosmani/status/1600553460180869120`

I don't know why this happens in this tweet.
I created a test that is coupled to this tweet specifically. Better to do it with Astro's tweeter user, but I don't know what caused this tweet to be without entities.

closes #27